### PR TITLE
Improved setup.py

### DIFF
--- a/lib/setup.py
+++ b/lib/setup.py
@@ -109,11 +109,13 @@ ext_modules = [
         "utils.cython_bbox",
         ["utils/bbox.pyx"],
         extra_compile_args={'gcc': ["-Wno-cpp", "-Wno-unused-function"]},
+        include_dirs = [numpy_include]
     ),
     Extension(
         "utils.cython_nms",
         ["utils/nms.pyx"],
         extra_compile_args={'gcc': ["-Wno-cpp", "-Wno-unused-function"]},
+        include_dirs = [numpy_include]
     ),
     Extension(
         "nms.cpu_nms",


### PR DESCRIPTION
Add numpy include path for ext utils.cython_bbox and utils.cython_nms. Without it, there could be an fatal error when searching for "numpy/arrayobject.h" for latest numpy versions installed by pip.