### PR TITLE
Changing strings to tuples

### DIFF
--- a/tools/demo.py
+++ b/tools/demo.py
@@ -37,8 +37,8 @@ CLASSES = ('__background__',
            'motorbike', 'person', 'pottedplant',
            'sheep', 'sofa', 'train', 'tvmonitor')
 
-NETS = {'vgg16': ('vgg16_faster_rcnn_iter_70000.ckpt'),'res101': ('res101_faster_rcnn_iter_110000.ckpt')}
-DATASETS= {'pascal_voc': ('voc_2007_trainval'),'pascal_voc_0712': ('voc_2007_trainval+voc_2012_trainval')}
+NETS = {'vgg16': ('vgg16_faster_rcnn_iter_70000.ckpt',),'res101': ('res101_faster_rcnn_iter_110000.ckpt',)}
+DATASETS= {'pascal_voc': ('voc_2007_trainval',),'pascal_voc_0712': ('voc_2007_trainval+voc_2012_trainval',)}
 def vis_detections(im, class_name, dets, thresh=0.5):
     """Draw detected bounding boxes."""
     inds = np.where(dets[:, -1] >= thresh)[0]


### PR DESCRIPTION
In the NETS and DATASETS dictionary, we have only a single element inside the tuple. Hence, it will be treated as strings, and not tuples. 

Hence, 
`tfmodel = os.path.join('../output',demonet,DATASETS[dataset][0], 'default', NETS[demonet][0]) `
in line 119 will compute :
`../output/res101/v/default/r.meta`

Hence the IOError in 124 fires, even if the data is present in the path and arguments are passed correctly. 

FIX would be to explicitly say that it is a tuple.

Ref: http://stackoverflow.com/questions/12876177/why-do-tuples-with-only-one-element-get-converted-to-strings