### PR TITLE
Correcting  'opencv-python' in the Prerequisite section

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Additional features not mentioned in the [report](https://arxiv.org/pdf/1702.021
 
 ### Prerequisites
   - A basic Tensorflow installation. The code follows **r1.0** format now. If you are using an order version (r0.1-r0.12), please check out the v0.12 release. While it is not required, for experimenting the original RoI pooling (which requires modification of the C++ code in tensorflow), you can check out my tensorflow [fork](https://github.com/endernewton/tensorflow) and look for ``tf.image.roi_pooling``.
-  - Python packages you might not have: `cython`, `python-opencv`, `easydict` (similar to [py-faster-rcnn](https://github.com/rbgirshick/py-faster-rcnn)).
+  - Python packages you might not have: `cython`, `opencv-python`, `easydict` (similar to [py-faster-rcnn](https://github.com/rbgirshick/py-faster-rcnn)).
   - Docker users: A Docker image containing all of the required dependencies can be found in Docker hub at the ``docker`` folder. The Docker file used to create this image can be found in the docker directory of this repository.
 
 ### Installation


### PR DESCRIPTION
FIX for https://github.com/endernewton/tf-faster-rcnn/issues/47