### PR TITLE
Fix a bug of path or it will raise ImportError: No module named pycoc…

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Additional features not mentioned in the [report](https://arxiv.org/pdf/1702.021
    cd ../..
    ```
 
-5. Install the [Python COCO API](https://github.com/pdollar/coco). And create a symbolic link to it within ``tf-faster-rcnn/data``, The code requires the API to access COCO dataset.
+5. Install the [Python COCO API](https://github.com/pdollar/coco). And create a symbolic link to it within ``tf-faster-rcnn/lib``, The code requires the API to access COCO dataset.
 
 ### Setup data
 Please follow the instructions of py-faster-rcnn [here](https://github.com/rbgirshick/py-faster-rcnn#beyond-the-demo-installation-for-training-and-testing-models) to setup VOC and COCO datasets. The steps involve downloading data and creating softlinks in the ``data`` folder. Since faster RCNN does not rely on pre-computed proposals, it is safe to ignore the steps that setup proposals.


### PR DESCRIPTION
Fix a bug of path or it will raise ImportError: No module named pycocotools.coco