### PR TITLE
fixed a minor pickle.dump error change from 'w'  to 'wb'.

### DIFF
--- a/lib/datasets/voc_eval.py
+++ b/lib/datasets/voc_eval.py
@@ -117,7 +117,7 @@ def voc_eval(detpath,
           i + 1, len(imagenames)))
     # save
     print('Saving cached annotations to {:s}'.format(cachefile))
-    with open(cachefile, 'w') as f:
+    with open(cachefile, 'wb') as f:
       pickle.dump(recs, f)
   else:
     # load


### PR DESCRIPTION
in voc_val.py script, when try to dump results to annots.pkl. File should be opened in 'wb' mode. A minor change.