### PR TITLE
Update README.md about docker usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Additional features not mentioned in the [report](https://arxiv.org/pdf/1702.021
 ### Prerequisites
   - A basic Tensorflow installation. The code follows **r1.0** format. If you are using an older version (r0.1-r0.12), please check out the v0.12 release. While it is not required, for experimenting the original RoI pooling (which requires modification of the C++ code in tensorflow), you can check out my tensorflow [fork](https://github.com/endernewton/tensorflow) and look for ``tf.image.roi_pooling``.
   - Python packages you might not have: `cython`, `opencv-python`, `easydict` (similar to [py-faster-rcnn](https://github.com/rbgirshick/py-faster-rcnn)). For `easydict` make sure you have the right version. I use 1.6.
-  - Docker users: Since recent upgrade Tensorflow **r1.0**, the docker image on docker hub (https://hub.docker.com/r/mbuckler/tf-faster-rcnn-deps/) is no longer valid. However, you can still build your own image by using dockerfile located at `docker` folder (cuda 8 version, as it is required by Tensorflow **r1.0**.) And make sure following Tensorflow installation to install and use nvidia-docker[https://github.com/NVIDIA/nvidia-docker].
+  - Docker users: Since recent upgrade Tensorflow **r1.0**, the docker image on docker hub (https://hub.docker.com/r/mbuckler/tf-faster-rcnn-deps/) is no longer valid. However, you can still build your own image by using dockerfile located at `docker` folder (cuda 8 version, as it is required by Tensorflow **r1.0**.) And make sure following Tensorflow installation to install and use nvidia-docker[https://github.com/NVIDIA/nvidia-docker]. Last, after launching the container, you have to build the Cython modules within the running container. 
 
 ### Installation
 1. Clone the repository

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Additional features not mentioned in the [report](https://arxiv.org/pdf/1702.021
 ### Prerequisites
   - A basic Tensorflow installation. The code follows **r1.0** format. If you are using an older version (r0.1-r0.12), please check out the v0.12 release. While it is not required, for experimenting the original RoI pooling (which requires modification of the C++ code in tensorflow), you can check out my tensorflow [fork](https://github.com/endernewton/tensorflow) and look for ``tf.image.roi_pooling``.
   - Python packages you might not have: `cython`, `opencv-python`, `easydict` (similar to [py-faster-rcnn](https://github.com/rbgirshick/py-faster-rcnn)). For `easydict` make sure you have the right version. I use 1.6.
-  - Docker users: A Docker image containing all of the required dependencies can be found in Docker hub at the ``docker`` folder. The Docker file used to create this image can be found in the docker directory of this repository.
+  - Docker users: Since recent upgrade Tensorflow **r1.0**, the docker image on docker hub (https://hub.docker.com/r/mbuckler/tf-faster-rcnn-deps/) is no longer valid. However, you can still build your own image by using dockerfile located at `docker` folder (cuda 8 version, as it is required by Tensorflow **r1.0**.) And make sure following Tensorflow installation to install and use nvidia-docker[https://github.com/NVIDIA/nvidia-docker].
 
 ### Installation
 1. Clone the repository


### PR DESCRIPTION
Hope this PR could save time for others. 
Ran into multiple issues:

1. docker image on docker hub is no longer valid after recent upgrade to Tensorflow r1.0
2. nvidia-docker seems to be a must, it takes care to mount host CUDA and GPU driver files correctly into container. Otherwise, will run into strange exception complaining can't load `libcuda.so.1`, and google results would confuse you 
3. for reason I haven't figure out, must make cython module within container. Otherwise, will get import error when other python script try to import the utility module.