### PR TITLE
Fix pickle error when saving cached annotations

### DIFF
--- a/lib/datasets/voc_eval.py
+++ b/lib/datasets/voc_eval.py
@@ -118,7 +118,7 @@ def voc_eval(detpath,
           i + 1, len(imagenames)))
     # save
     print('Saving cached annotations to {:s}'.format(cachefile))
-    with open(cachefile, 'w') as f:
+    with open(cachefile, 'wb') as f:
       pickle.dump(recs, f)
   else:
     # load


### PR DESCRIPTION
I got a error when run `test_faster_rcnn.sh`
```
Saving cached annotations to /root/Workspace/tf-faster-rcnn/data/VOCdevkit2007/VOC2007/ImageSets/Main/test.txt_annots.pkl
Traceback (most recent call last):
  File "./tools/test_net.py", line 121, in <module>
    test_net(sess, net, imdb, filename, max_per_image=args.max_per_image)
  File "/root/Workspace/tf-faster-rcnn/tools/../lib/model/test.py", line 192, in test_net
    imdb.evaluate_detections(all_boxes, output_dir)
  File "/root/Workspace/tf-faster-rcnn/tools/../lib/datasets/pascal_voc.py", line 283, in evaluate_detections
    self._do_python_eval(output_dir)
  File "/root/Workspace/tf-faster-rcnn/tools/../lib/datasets/pascal_voc.py", line 246, in _do_python_eval
    use_07_metric=use_07_metric, use_diff=self.config['use_diff'])
  File "/root/Workspace/tf-faster-rcnn/tools/../lib/datasets/voc_eval.py", line 122, in voc_eval
    pickle.dump(recs, f)
TypeError: write() argument must be str, not bytes
```

I  think that cache file open as text file.