### PR TITLE
Convert functions needed for inference to pure tensorflow.

### DIFF
--- a/lib/layer_utils/proposal_layer.py
+++ b/lib/layer_utils/proposal_layer.py
@@ -53,6 +53,7 @@ def proposal_layer(rpn_cls_prob, rpn_bbox_pred, im_info, cfg_key, _feat_stride, 
 
   return blob, scores
 
+
 def proposal_layer_tf(rpn_cls_prob, rpn_bbox_pred, im_info, cfg_key, _feat_stride, anchors, num_anchors):
   if type(cfg_key) == bytes:
     cfg_key = cfg_key.decode('utf-8')
@@ -67,9 +68,9 @@ def proposal_layer_tf(rpn_cls_prob, rpn_bbox_pred, im_info, cfg_key, _feat_strid
   proposals = bbox_transform_inv_tf(anchors, rpn_bbox_pred)
   proposals = clip_boxes_tf(proposals, im_info[:2])
 
-  indices = tf.image.non_max_suppression(rpn_bbox_pred, scores, max_output_size=post_nms_topN, iou_threshold=nms_thresh)
+  indices = tf.image.non_max_suppression(proposals, scores, max_output_size=post_nms_topN, iou_threshold=nms_thresh)
 
-  boxes = tf.gather(rpn_bbox_pred, indices)
+  boxes = tf.gather(proposals, indices)
   boxes = tf.to_float(boxes)
   scores = tf.gather(scores, indices)
   scores = tf.reshape(scores, shape=(-1, 1))

--- a/lib/layer_utils/proposal_layer.py
+++ b/lib/layer_utils/proposal_layer.py
@@ -7,9 +7,10 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import tensorflow as tf
 import numpy as np
 from model.config import cfg
-from model.bbox_transform import bbox_transform_inv, clip_boxes
+from model.bbox_transform import bbox_transform_inv, clip_boxes, bbox_transform_inv_tf, clip_boxes_tf
 from model.nms_wrapper import nms
 
 
@@ -50,4 +51,32 @@ def proposal_layer(rpn_cls_prob, rpn_bbox_pred, im_info, cfg_key, _feat_stride, 
   batch_inds = np.zeros((proposals.shape[0], 1), dtype=np.float32)
   blob = np.hstack((batch_inds, proposals.astype(np.float32, copy=False)))
 
+  return blob, scores
+
+def proposal_layer_tf(rpn_cls_prob, rpn_bbox_pred, im_info, cfg_key, _feat_stride, anchors, num_anchors):
+  if type(cfg_key) == bytes:
+    cfg_key = cfg_key.decode('utf-8')
+  pre_nms_topN = cfg[cfg_key].RPN_PRE_NMS_TOP_N
+  post_nms_topN = cfg[cfg_key].RPN_POST_NMS_TOP_N
+  nms_thresh = cfg[cfg_key].RPN_NMS_THRESH
+
+  scores = rpn_cls_prob[:, :, :, num_anchors:]
+  scores = tf.reshape(scores, shape=(-1,))
+  rpn_bbox_pred = tf.reshape(rpn_bbox_pred, shape=(-1, 4))
+
+  proposals = bbox_transform_inv_tf(anchors, rpn_bbox_pred)
+  proposals = clip_boxes_tf(proposals, im_info[:2])
+
+  indices = tf.image.non_max_suppression(rpn_bbox_pred, scores, max_output_size=post_nms_topN, iou_threshold=nms_thresh)
+
+  boxes = tf.gather(rpn_bbox_pred, indices)
+  boxes = tf.to_float(boxes)
+  scores = tf.gather(scores, indices)
+  scores = tf.reshape(scores, shape=(-1, 1))
+
+
+  batch_inds = tf.zeros((tf.shape(indices)[0], 1), dtype=tf.float32)
+  blob = tf.concat([batch_inds, boxes], 1)
+
+  assert blob.get_shape()[1] == 5
   return blob, scores

--- a/lib/layer_utils/proposal_layer.py
+++ b/lib/layer_utils/proposal_layer.py
@@ -15,52 +15,13 @@ from model.nms_wrapper import nms
 
 
 def proposal_layer(rpn_cls_prob, rpn_bbox_pred, im_info, cfg_key, _feat_stride, anchors, num_anchors):
-  """A simplified version compared to fast/er RCNN
-     For details please see the technical report
-  """
-  if type(cfg_key) == bytes:
-      cfg_key = cfg_key.decode('utf-8')
-  pre_nms_topN = cfg[cfg_key].RPN_PRE_NMS_TOP_N
-  post_nms_topN = cfg[cfg_key].RPN_POST_NMS_TOP_N
-  nms_thresh = cfg[cfg_key].RPN_NMS_THRESH
-
-  # Get the scores and bounding boxes
-  scores = rpn_cls_prob[:, :, :, num_anchors:]
-  rpn_bbox_pred = rpn_bbox_pred.reshape((-1, 4))
-  scores = scores.reshape((-1, 1))
-  proposals = bbox_transform_inv(anchors, rpn_bbox_pred)
-  proposals = clip_boxes(proposals, im_info[:2])
-
-  # Pick the top region proposals
-  order = scores.ravel().argsort()[::-1]
-  if pre_nms_topN > 0:
-    order = order[:pre_nms_topN]
-  proposals = proposals[order, :]
-  scores = scores[order]
-
-  # Non-maximal suppression
-  keep = nms(np.hstack((proposals, scores)), nms_thresh)
-
-  # Pick th top region proposals after NMS
-  if post_nms_topN > 0:
-    keep = keep[:post_nms_topN]
-  proposals = proposals[keep, :]
-  scores = scores[keep]
-
-  # Only support single image as input
-  batch_inds = np.zeros((proposals.shape[0], 1), dtype=np.float32)
-  blob = np.hstack((batch_inds, proposals.astype(np.float32, copy=False)))
-
-  return blob, scores
-
-
-def proposal_layer_tf(rpn_cls_prob, rpn_bbox_pred, im_info, cfg_key, _feat_stride, anchors, num_anchors):
   if type(cfg_key) == bytes:
     cfg_key = cfg_key.decode('utf-8')
   pre_nms_topN = cfg[cfg_key].RPN_PRE_NMS_TOP_N
   post_nms_topN = cfg[cfg_key].RPN_POST_NMS_TOP_N
   nms_thresh = cfg[cfg_key].RPN_NMS_THRESH
 
+  # Get the scores and bounding boxes
   scores = rpn_cls_prob[:, :, :, num_anchors:]
   scores = tf.reshape(scores, shape=(-1,))
   rpn_bbox_pred = tf.reshape(rpn_bbox_pred, shape=(-1, 4))
@@ -68,6 +29,7 @@ def proposal_layer_tf(rpn_cls_prob, rpn_bbox_pred, im_info, cfg_key, _feat_strid
   proposals = bbox_transform_inv_tf(anchors, rpn_bbox_pred)
   proposals = clip_boxes_tf(proposals, im_info[:2])
 
+  # Non-maximal suppression
   indices = tf.image.non_max_suppression(proposals, scores, max_output_size=post_nms_topN, iou_threshold=nms_thresh)
 
   boxes = tf.gather(proposals, indices)
@@ -75,9 +37,8 @@ def proposal_layer_tf(rpn_cls_prob, rpn_bbox_pred, im_info, cfg_key, _feat_strid
   scores = tf.gather(scores, indices)
   scores = tf.reshape(scores, shape=(-1, 1))
 
-
+  # Only support single image as input
   batch_inds = tf.zeros((tf.shape(indices)[0], 1), dtype=tf.float32)
   blob = tf.concat([batch_inds, boxes], 1)
 
-  assert blob.get_shape()[1] == 5
   return blob, scores

--- a/lib/layer_utils/proposal_top_layer.py
+++ b/lib/layer_utils/proposal_top_layer.py
@@ -9,8 +9,10 @@ from __future__ import print_function
 
 import numpy as np
 from model.config import cfg
-from model.bbox_transform import bbox_transform_inv, clip_boxes
+from model.bbox_transform import bbox_transform_inv, clip_boxes, bbox_transform_inv_tf, clip_boxes_tf
 import numpy.random as npr
+
+import tensorflow as tf
 
 def proposal_top_layer(rpn_cls_prob, rpn_bbox_pred, im_info, _feat_stride, anchors, num_anchors):
   """A layer that just selects the top region proposals
@@ -51,3 +53,21 @@ def proposal_top_layer(rpn_cls_prob, rpn_bbox_pred, im_info, _feat_stride, ancho
   batch_inds = np.zeros((proposals.shape[0], 1), dtype=np.float32)
   blob = np.hstack((batch_inds, proposals.astype(np.float32, copy=False)))
   return blob, scores
+
+def proposal_top_layer_tf(rpn_cls_prob, rpn_bbox_pred, im_info, _feat_stride, anchors, num_anchors):
+  rpn_top_n = cfg.TEST.RPN_TOP_N
+
+  scores = rpn_cls_prob[:, :, :, num_anchors:]
+  rpn_bbox_pred = tf.reshape(rpn_bbox_pred, shape=(-1, 4))
+  scores = tf.reshape(scores, shape=(-1,))
+
+  top_scores, top_inds = tf.nn.top_k(scores, k=rpn_top_n)
+  top_scores = tf.reshape(top_scores, shape=(-1, 1))
+  top_anchors = tf.gather(anchors, top_inds)
+  top_rpn_bbox = tf.gather(rpn_bbox_pred, top_inds)
+  proposals = bbox_transform_inv_tf(top_anchors, top_rpn_bbox)
+  proposals = clip_boxes_tf(proposals, im_info[:2])
+  proposals = tf.to_float(proposals)
+  batch_inds = tf.zeros((rpn_top_n, 1))
+  blob = tf.concat([batch_inds, proposals], 1)
+  return blob, top_scores

--- a/lib/layer_utils/proposal_top_layer.py
+++ b/lib/layer_utils/proposal_top_layer.py
@@ -7,10 +7,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import numpy as np
 from model.config import cfg
 from model.bbox_transform import bbox_transform_inv, clip_boxes, bbox_transform_inv_tf, clip_boxes_tf
-import numpy.random as npr
 
 import tensorflow as tf
 
@@ -22,51 +20,22 @@ def proposal_top_layer(rpn_cls_prob, rpn_bbox_pred, im_info, _feat_stride, ancho
   rpn_top_n = cfg.TEST.RPN_TOP_N
 
   scores = rpn_cls_prob[:, :, :, num_anchors:]
-
-  rpn_bbox_pred = rpn_bbox_pred.reshape((-1, 4))
-  scores = scores.reshape((-1, 1))
-
-  length = scores.shape[0]
-  if length < rpn_top_n:
-    # Random selection, maybe unnecessary and loses good proposals
-    # But such case rarely happens
-    top_inds = npr.choice(length, size=rpn_top_n, replace=True)
-  else:
-    top_inds = scores.argsort(0)[::-1]
-    top_inds = top_inds[:rpn_top_n]
-    top_inds = top_inds.reshape(rpn_top_n, )
-
-  # Do the selection here
-  anchors = anchors[top_inds, :]
-  rpn_bbox_pred = rpn_bbox_pred[top_inds, :]
-  scores = scores[top_inds]
-
-  # Convert anchors into proposals via bbox transformations
-  proposals = bbox_transform_inv(anchors, rpn_bbox_pred)
-
-  # Clip predicted boxes to image
-  proposals = clip_boxes(proposals, im_info[:2])
-
-  # Output rois blob
-  # Our RPN implementation only supports a single input image, so all
-  # batch inds are 0
-  batch_inds = np.zeros((proposals.shape[0], 1), dtype=np.float32)
-  blob = np.hstack((batch_inds, proposals.astype(np.float32, copy=False)))
-  return blob, scores
-
-def proposal_top_layer_tf(rpn_cls_prob, rpn_bbox_pred, im_info, _feat_stride, anchors, num_anchors):
-  rpn_top_n = cfg.TEST.RPN_TOP_N
-
-  scores = rpn_cls_prob[:, :, :, num_anchors:]
   rpn_bbox_pred = tf.reshape(rpn_bbox_pred, shape=(-1, 4))
   scores = tf.reshape(scores, shape=(-1,))
 
+  # Do the selection here
   top_scores, top_inds = tf.nn.top_k(scores, k=rpn_top_n)
   top_scores = tf.reshape(top_scores, shape=(-1, 1))
   top_anchors = tf.gather(anchors, top_inds)
   top_rpn_bbox = tf.gather(rpn_bbox_pred, top_inds)
   proposals = bbox_transform_inv_tf(top_anchors, top_rpn_bbox)
+
+  # Clip predicted boxes to image
   proposals = clip_boxes_tf(proposals, im_info[:2])
+
+  # Output rois blob
+  # Our RPN implementation only supports a single input image, so all
+  # batch inds are 0
   proposals = tf.to_float(proposals)
   batch_inds = tf.zeros((rpn_top_n, 1))
   blob = tf.concat([batch_inds, proposals], 1)

--- a/lib/layer_utils/snippets.py
+++ b/lib/layer_utils/snippets.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import tensorflow as tf
 import numpy as np
 from layer_utils.generate_anchors import generate_anchors
 
@@ -27,3 +28,23 @@ def generate_anchors_pre(height, width, feat_stride, anchor_scales=(8,16,32), an
   length = np.int32(anchors.shape[0])
 
   return anchors, length
+
+def generate_anchors_tf(height, width, feat_stride=16, anchor_scales=(8, 16, 32), anchor_ratios=(0.5, 1, 2)):
+  shift_x = tf.range(width) * feat_stride # width
+  shift_y = tf.range(height) * feat_stride # height
+  shift_x, shift_y = tf.meshgrid(shift_x, shift_y)
+  sx = tf.reshape(shift_x, shape=(-1,))
+  sy = tf.reshape(shift_y, shape=(-1,))
+  shifts = tf.transpose(tf.stack([sx, sy, sx, sy]))
+  K = tf.multiply(width, height)
+  shifts = tf.transpose(tf.reshape(shifts, shape=[1, K, 4]), perm=(1, 0, 2))
+
+  anchors = generate_anchors(ratios=np.array(anchor_ratios), scales=np.array(anchor_scales))
+  A = anchors.shape[0]
+  anchor_constant = tf.constant(anchors.reshape((1, A, 4)), dtype=tf.int32)
+
+  length = K * A
+  anchors_tf = tf.reshape(tf.add(anchor_constant, shifts), shape=(length, 4))
+  
+  return tf.cast(anchors_tf, dtype=tf.float32), length
+

--- a/lib/layer_utils/snippets.py
+++ b/lib/layer_utils/snippets.py
@@ -11,25 +11,7 @@ import tensorflow as tf
 import numpy as np
 from layer_utils.generate_anchors import generate_anchors
 
-def generate_anchors_pre(height, width, feat_stride, anchor_scales=(8,16,32), anchor_ratios=(0.5,1,2)):
-  """ A wrapper function to generate anchors given different scales
-    Also return the number of anchors in variable 'length'
-  """
-  anchors = generate_anchors(ratios=np.array(anchor_ratios), scales=np.array(anchor_scales))
-  A = anchors.shape[0]
-  shift_x = np.arange(0, width) * feat_stride
-  shift_y = np.arange(0, height) * feat_stride
-  shift_x, shift_y = np.meshgrid(shift_x, shift_y)
-  shifts = np.vstack((shift_x.ravel(), shift_y.ravel(), shift_x.ravel(), shift_y.ravel())).transpose()
-  K = shifts.shape[0]
-  # width changes faster, so here it is H, W, C
-  anchors = anchors.reshape((1, A, 4)) + shifts.reshape((1, K, 4)).transpose((1, 0, 2))
-  anchors = anchors.reshape((K * A, 4)).astype(np.float32, copy=False)
-  length = np.int32(anchors.shape[0])
-
-  return anchors, length
-
-def generate_anchors_tf(height, width, feat_stride=16, anchor_scales=(8, 16, 32), anchor_ratios=(0.5, 1, 2)):
+def generate_anchors_pre(height, width, feat_stride=16, anchor_scales=(8, 16, 32), anchor_ratios=(0.5, 1, 2)):
   shift_x = tf.range(width) * feat_stride # width
   shift_y = tf.range(height) * feat_stride # height
   shift_x, shift_y = tf.meshgrid(shift_x, shift_y)

--- a/lib/model/bbox_transform.py
+++ b/lib/model/bbox_transform.py
@@ -9,6 +9,7 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
+import tensorflow as tf
 
 def bbox_transform(ex_rois, gt_rois):
   ex_widths = ex_rois[:, 2] - ex_rois[:, 0] + 1.0
@@ -78,3 +79,39 @@ def clip_boxes(boxes, im_shape):
   # y2 < im_shape[0]
   boxes[:, 3::4] = np.maximum(np.minimum(boxes[:, 3::4], im_shape[0] - 1), 0)
   return boxes
+
+
+
+def bbox_transform_inv_tf(boxes, deltas):
+  boxes = tf.cast(boxes, deltas.dtype)
+  widths = tf.subtract(boxes[:, 2], boxes[:, 0]) + 1.0
+  heights = tf.subtract(boxes[:, 3], boxes[:, 1]) + 1.0
+  ctr_x = tf.add(boxes[:, 0], widths * 0.5)
+  ctr_y = tf.add(boxes[:, 1], heights * 0.5)
+
+  dx = deltas[:, 0]
+  dy = deltas[:, 1]
+  dw = deltas[:, 2]
+  dh = deltas[:, 3]
+
+  pred_ctr_x = tf.add(tf.multiply(dx, widths), ctr_x)
+  pred_ctr_y = tf.add(tf.multiply(dy, widths), ctr_y)
+  pred_w = tf.multiply(tf.exp(dw), widths)
+  pred_h = tf.multiply(tf.exp(dh), heights)
+
+  pred_boxes0 = tf.subtract(pred_ctr_x, pred_w * 0.5)
+  pred_boxes1 = tf.subtract(pred_ctr_y, pred_h * 0.5)
+  pred_boxes2 = tf.add(pred_ctr_x, pred_w * 0.5)
+  pred_boxes3 = tf.add(pred_ctr_y, pred_h * 0.5)
+
+  return tf.stack([pred_boxes0, pred_boxes1, pred_boxes2, pred_boxes3], axis=1)
+
+
+def clip_boxes_tf(boxes, im_info):
+  b0 = tf.maximum(tf.minimum(boxes[:, 0], im_info[1] - 1), 0)
+  b1 = tf.maximum(tf.minimum(boxes[:, 1], im_info[0] - 1), 0)
+  b2 = tf.maximum(tf.minimum(boxes[:, 2], im_info[1] - 1), 0)
+  b3 = tf.maximum(tf.minimum(boxes[:, 3], im_info[0] - 1), 0)
+  return tf.stack([b0, b1, b2, b3], axis=1)
+
+

--- a/lib/nets/network.py
+++ b/lib/nets/network.py
@@ -106,19 +106,19 @@ class Network(object):
 
   def _proposal_layer(self, rpn_cls_prob, rpn_bbox_pred, name):
     with tf.variable_scope(name) as scope:
-      # rois, rpn_scores = proposal_layer_tf(
-      #   rpn_cls_prob,
-      #   rpn_bbox_pred,
-      #   self._im_info,
-      #   self._mode,
-      #   self._feat_stride,
-      #   self._anchors,
-      #   self._num_anchors
-      # )
-      rois, rpn_scores = tf.py_func(proposal_layer,
-                              [rpn_cls_prob, rpn_bbox_pred, self._im_info, self._mode,
-                               self._feat_stride, self._anchors, self._num_anchors],
-                              [tf.float32, tf.float32], name="proposal")
+      rois, rpn_scores = proposal_layer_tf(
+        rpn_cls_prob,
+        rpn_bbox_pred,
+        self._im_info,
+        self._mode,
+        self._feat_stride,
+        self._anchors,
+        self._num_anchors
+      )
+      # rois, rpn_scores = tf.py_func(proposal_layer,
+      #                         [rpn_cls_prob, rpn_bbox_pred, self._im_info, self._mode,
+      #                          self._feat_stride, self._anchors, self._num_anchors],
+      #                         [tf.float32, tf.float32], name="proposal")
       rois.set_shape([None, 5])
       rpn_scores.set_shape([None, 1])
 

--- a/lib/nets/network.py
+++ b/lib/nets/network.py
@@ -16,7 +16,7 @@ import numpy as np
 
 from layer_utils.snippets import generate_anchors_pre, generate_anchors_tf
 from layer_utils.proposal_layer import proposal_layer, proposal_layer_tf
-from layer_utils.proposal_top_layer import proposal_top_layer
+from layer_utils.proposal_top_layer import proposal_top_layer, proposal_top_layer_tf
 from layer_utils.anchor_target_layer import anchor_target_layer
 from layer_utils.proposal_target_layer import proposal_target_layer
 from utils.visualization import draw_bounding_boxes
@@ -87,10 +87,18 @@ class Network(object):
 
   def _proposal_top_layer(self, rpn_cls_prob, rpn_bbox_pred, name):
     with tf.variable_scope(name) as scope:
-      rois, rpn_scores = tf.py_func(proposal_top_layer,
-                                    [rpn_cls_prob, rpn_bbox_pred, self._im_info,
-                                     self._feat_stride, self._anchors, self._num_anchors],
-                                    [tf.float32, tf.float32], name="proposal_top")
+      rois, rpn_scores = proposal_top_layer_tf(
+        rpn_cls_prob,
+        rpn_bbox_pred,
+        self._im_info,
+        self._feat_stride,
+        self._anchors,
+        self._num_anchors
+      )
+      # rois, rpn_scores = tf.py_func(proposal_top_layer,
+      #                               [rpn_cls_prob, rpn_bbox_pred, self._im_info,
+      #                                self._feat_stride, self._anchors, self._num_anchors],
+      #                               [tf.float32, tf.float32], name="proposal_top")
       rois.set_shape([cfg.TEST.RPN_TOP_N, 5])
       rpn_scores.set_shape([cfg.TEST.RPN_TOP_N, 1])
 
@@ -98,15 +106,19 @@ class Network(object):
 
   def _proposal_layer(self, rpn_cls_prob, rpn_bbox_pred, name):
     with tf.variable_scope(name) as scope:
-      rois, rpn_scores = proposal_layer_tf(
-        rpn_cls_prob,
-        rpn_bbox_pred,
-        self._im_info,
-        self._mode,
-        self._feat_stride,
-        self._anchors,
-        self._num_anchors
-      )
+      # rois, rpn_scores = proposal_layer_tf(
+      #   rpn_cls_prob,
+      #   rpn_bbox_pred,
+      #   self._im_info,
+      #   self._mode,
+      #   self._feat_stride,
+      #   self._anchors,
+      #   self._num_anchors
+      # )
+      rois, rpn_scores = tf.py_func(proposal_layer,
+                              [rpn_cls_prob, rpn_bbox_pred, self._im_info, self._mode,
+                               self._feat_stride, self._anchors, self._num_anchors],
+                              [tf.float32, tf.float32], name="proposal")
       rois.set_shape([None, 5])
       rpn_scores.set_shape([None, 1])
 

--- a/lib/nets/network.py
+++ b/lib/nets/network.py
@@ -14,9 +14,9 @@ from tensorflow.contrib.slim import arg_scope
 
 import numpy as np
 
-from layer_utils.snippets import generate_anchors_pre, generate_anchors_tf
-from layer_utils.proposal_layer import proposal_layer, proposal_layer_tf
-from layer_utils.proposal_top_layer import proposal_top_layer, proposal_top_layer_tf
+from layer_utils.snippets import generate_anchors_pre
+from layer_utils.proposal_layer import proposal_layer
+from layer_utils.proposal_top_layer import proposal_top_layer
 from layer_utils.anchor_target_layer import anchor_target_layer
 from layer_utils.proposal_target_layer import proposal_target_layer
 from utils.visualization import draw_bounding_boxes
@@ -87,7 +87,7 @@ class Network(object):
 
   def _proposal_top_layer(self, rpn_cls_prob, rpn_bbox_pred, name):
     with tf.variable_scope(name) as scope:
-      rois, rpn_scores = proposal_top_layer_tf(
+      rois, rpn_scores = proposal_top_layer(
         rpn_cls_prob,
         rpn_bbox_pred,
         self._im_info,
@@ -95,10 +95,6 @@ class Network(object):
         self._anchors,
         self._num_anchors
       )
-      # rois, rpn_scores = tf.py_func(proposal_top_layer,
-      #                               [rpn_cls_prob, rpn_bbox_pred, self._im_info,
-      #                                self._feat_stride, self._anchors, self._num_anchors],
-      #                               [tf.float32, tf.float32], name="proposal_top")
       rois.set_shape([cfg.TEST.RPN_TOP_N, 5])
       rpn_scores.set_shape([cfg.TEST.RPN_TOP_N, 1])
 
@@ -106,7 +102,7 @@ class Network(object):
 
   def _proposal_layer(self, rpn_cls_prob, rpn_bbox_pred, name):
     with tf.variable_scope(name) as scope:
-      rois, rpn_scores = proposal_layer_tf(
+      rois, rpn_scores = proposal_layer(
         rpn_cls_prob,
         rpn_bbox_pred,
         self._im_info,
@@ -115,10 +111,6 @@ class Network(object):
         self._anchors,
         self._num_anchors
       )
-      # rois, rpn_scores = tf.py_func(proposal_layer,
-      #                         [rpn_cls_prob, rpn_bbox_pred, self._im_info, self._mode,
-      #                          self._feat_stride, self._anchors, self._num_anchors],
-      #                         [tf.float32, tf.float32], name="proposal")
       rois.set_shape([None, 5])
       rpn_scores.set_shape([None, 1])
 
@@ -206,11 +198,13 @@ class Network(object):
       # just to get the shape right
       height = tf.to_int32(tf.ceil(self._im_info[0] / np.float32(self._feat_stride[0])))
       width = tf.to_int32(tf.ceil(self._im_info[1] / np.float32(self._feat_stride[0])))
-      anchors, anchor_length = generate_anchors_tf(height, width, self._feat_stride, self._anchor_scales, self._anchor_ratios)
-      # anchors, anchor_length = tf.py_func(generate_anchors_pre,
-      #                                     [height, width,
-      #                                      self._feat_stride, self._anchor_scales, self._anchor_ratios],
-      #                                     [tf.float32, tf.int32], name="generate_anchors")
+      anchors, anchor_length = generate_anchors_pre(
+        height,
+        width,
+        self._feat_stride,
+        self._anchor_scales,
+        self._anchor_ratios
+      )
       anchors.set_shape([None, 4])
       anchor_length.set_shape([])
       self._anchors = anchors

--- a/lib/nets/network.py
+++ b/lib/nets/network.py
@@ -15,7 +15,7 @@ from tensorflow.contrib.slim import arg_scope
 import numpy as np
 
 from layer_utils.snippets import generate_anchors_pre, generate_anchors_tf
-from layer_utils.proposal_layer import proposal_layer
+from layer_utils.proposal_layer import proposal_layer, proposal_layer_tf
 from layer_utils.proposal_top_layer import proposal_top_layer
 from layer_utils.anchor_target_layer import anchor_target_layer
 from layer_utils.proposal_target_layer import proposal_target_layer
@@ -98,10 +98,15 @@ class Network(object):
 
   def _proposal_layer(self, rpn_cls_prob, rpn_bbox_pred, name):
     with tf.variable_scope(name) as scope:
-      rois, rpn_scores = tf.py_func(proposal_layer,
-                                    [rpn_cls_prob, rpn_bbox_pred, self._im_info, self._mode,
-                                     self._feat_stride, self._anchors, self._num_anchors],
-                                    [tf.float32, tf.float32], name="proposal")
+      rois, rpn_scores = proposal_layer_tf(
+        rpn_cls_prob,
+        rpn_bbox_pred,
+        self._im_info,
+        self._mode,
+        self._feat_stride,
+        self._anchors,
+        self._num_anchors
+      )
       rois.set_shape([None, 5])
       rpn_scores.set_shape([None, 1])
 

--- a/lib/nets/network.py
+++ b/lib/nets/network.py
@@ -14,7 +14,7 @@ from tensorflow.contrib.slim import arg_scope
 
 import numpy as np
 
-from layer_utils.snippets import generate_anchors_pre
+from layer_utils.snippets import generate_anchors_pre, generate_anchors_tf
 from layer_utils.proposal_layer import proposal_layer
 from layer_utils.proposal_top_layer import proposal_top_layer
 from layer_utils.anchor_target_layer import anchor_target_layer
@@ -189,10 +189,11 @@ class Network(object):
       # just to get the shape right
       height = tf.to_int32(tf.ceil(self._im_info[0] / np.float32(self._feat_stride[0])))
       width = tf.to_int32(tf.ceil(self._im_info[1] / np.float32(self._feat_stride[0])))
-      anchors, anchor_length = tf.py_func(generate_anchors_pre,
-                                          [height, width,
-                                           self._feat_stride, self._anchor_scales, self._anchor_ratios],
-                                          [tf.float32, tf.int32], name="generate_anchors")
+      anchors, anchor_length = generate_anchors_tf(height, width, self._feat_stride, self._anchor_scales, self._anchor_ratios)
+      # anchors, anchor_length = tf.py_func(generate_anchors_pre,
+      #                                     [height, width,
+      #                                      self._feat_stride, self._anchor_scales, self._anchor_ratios],
+      #                                     [tf.float32, tf.int32], name="generate_anchors")
       anchors.set_shape([None, 4])
       anchor_length.set_shape([])
       self._anchors = anchors


### PR DESCRIPTION
Currently, the code for `generate_anchors_pre`, `proposal_layer`, and `proposal_top_layer` use `tf.py_func`, which makes the model generated by this code unusable for export. This pull request implements these functions in pure tensorflow operations, so the model can be used on different devices and runtimes.

Using pure tensorflow also has a couple of other benefits, such as tensorflow's built in `optimize_for_inference` function. In my experience this cuts off 10-15% of the inference time.